### PR TITLE
Fix build on GNU/Linux and FreeBSD

### DIFF
--- a/miruo.c
+++ b/miruo.c
@@ -2104,7 +2104,9 @@ void miruo_init_pcap()
     case DLT_EN10MB:
     case DLT_LINUX_SLL:
     case DLT_RAW:
+#ifdef __APPLE__
     case DLT_PKTAP:
+#endif
     case DLT_NULL:
     case DLT_LOOP:
       break;


### PR DESCRIPTION
DLT_PKTAP is defined only on OS X.

OS X でしかビルドできなくなっていました。